### PR TITLE
🔀::7 - 테이블 이름 수정

### DIFF
--- a/src/main/kotlin/team/iwfsg/fsg/domain/order/domain/Orders.kt
+++ b/src/main/kotlin/team/iwfsg/fsg/domain/order/domain/Orders.kt
@@ -2,7 +2,7 @@ package team.iwfsg.fsg.domain.order.domain
 
 import java.time.LocalDateTime
 
-data class Order(
+data class Orders(
     val id: Long,
     val userId: Long,
     val productId: Long,

--- a/src/main/kotlin/team/iwfsg/fsg/domain/order/persistence/entity/OrdersJpaEntity.kt
+++ b/src/main/kotlin/team/iwfsg/fsg/domain/order/persistence/entity/OrdersJpaEntity.kt
@@ -8,8 +8,8 @@ import team.iwfsg.fsg.domain.user.persistence.entity.UserJpaEntity
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "order")
-class OrderJpaEntity(
+@Table(name = "orders")
+class OrdersJpaEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long,

--- a/src/main/kotlin/team/iwfsg/fsg/domain/order/persistence/repository/OrderRepository.kt
+++ b/src/main/kotlin/team/iwfsg/fsg/domain/order/persistence/repository/OrderRepository.kt
@@ -1,7 +1,7 @@
 package team.iwfsg.fsg.domain.order.persistence.repository
 
 import org.springframework.data.repository.CrudRepository
-import team.iwfsg.fsg.domain.order.persistence.entity.OrderJpaEntity
+import team.iwfsg.fsg.domain.order.persistence.entity.OrdersJpaEntity
 
-interface OrderRepository : CrudRepository<OrderJpaEntity, Long> {
+interface OrderRepository : CrudRepository<OrdersJpaEntity, Long> {
 }

--- a/src/main/kotlin/team/iwfsg/fsg/domain/order/persistence/repository/OrdersRepository.kt
+++ b/src/main/kotlin/team/iwfsg/fsg/domain/order/persistence/repository/OrdersRepository.kt
@@ -3,5 +3,5 @@ package team.iwfsg.fsg.domain.order.persistence.repository
 import org.springframework.data.repository.CrudRepository
 import team.iwfsg.fsg.domain.order.persistence.entity.OrdersJpaEntity
 
-interface OrderRepository : CrudRepository<OrdersJpaEntity, Long> {
+interface OrdersRepository : CrudRepository<OrdersJpaEntity, Long> {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,5 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${JPA_DDL_AUTO}
+server:
+  port: {SERVER_PORT}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,4 +8,4 @@ spring:
     hibernate:
       ddl-auto: ${JPA_DDL_AUTO}
 server:
-  port: {SERVER_PORT}
+  port: ${SERVER_PORT}

--- a/src/test/kotlin/team/iwfsg/fsg/domain/order/repository/OrderRepositoryTest.kt
+++ b/src/test/kotlin/team/iwfsg/fsg/domain/order/repository/OrderRepositoryTest.kt
@@ -4,12 +4,12 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldNotBe
 import io.mockk.mockk
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import team.iwfsg.fsg.domain.order.persistence.repository.OrderRepository
+import team.iwfsg.fsg.domain.order.persistence.repository.OrdersRepository
 
 @DataJpaTest
 class OrderRepositoryTest : BehaviorSpec({
     Given("orderRepository") {
-        val orderRepository = mockk<OrderRepository>()
+        val orderRepository = mockk<OrdersRepository>()
            When("Create OrderRepository") {
                Then("OrderRepository is not null") {
                    orderRepository shouldNotBe null


### PR DESCRIPTION
## 💡 개요
주문에 사용한 order 테이블 이름이 MySQL 예약어로 에러가 발생했습니다.
## 📃 작업내용
order를 사용하는 클래스들을 orders로 변경했습니다.
## 🔀 변경사항
* order -> orders로 도메인 class 이름 변경했습니다.
* orderJpaEntity -> ordersJpaEntity로 변경 & table 옵션 orders로 변경했습니다.
* orderRepository -> ordersRepository로 변경했습니다.
* application.yml에 server.port 옵션 추가
## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
